### PR TITLE
ignore m4

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# .gitattributes - configure Git options
+
+## github-linguist config
+
+*.m4 -linguist-detectable
+# ignore m4 files

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# linguist - fucking ignore M4 files please
-*.m4 -linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# linguist - fucking ignore M4 files please
+*.m4 -linguist-detectable


### PR DESCRIPTION
- Added gitattributes to ignore fucking M4 files
- Revert "Added gitattributes to ignore fucking M4 files"
- prevent Linguist from detecting M4 files
